### PR TITLE
Build: Enable LibGL and x86_64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ Build like a regular Serenity Port.
 In the `quake2` port directory, run `./package.sh`.
 
 You'll then need to source the QuakeII demo pak file yourself. iD's FTP is offline, however you can find the demo in a few places. Once you've downloaded the demo, move the `pak0.pak` file to `/home/anon/.quake2/baseq2/` and run `quake2` from the command line. 
+
+Running with OpenGL
+-------------------
+
+Dynamically switching between software rendering and LibGL does not yet work; to run Quake2 in OpenGL mode, add the
+following statements to `~/.quake2/baseq2/config.cfg`:
+
+```
+set vid_ref "sdlgl"
+set gl_driver "libgl.so.serenity"
+```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
-set (quake_resource_libdir /usr/local/lib/quake2sdl)
-set (quake_resource_datadir /usr/local/share/quake2)
+set (quake_resource_libdir ${CMAKE_INSTALL_PREFIX}/lib/quake2sdl)
+set (quake_resource_datadir ${CMAKE_INSTALL_PREFIX}/share/quake2)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/q_resources.h.in ${CMAKE_CURRENT_BINARY_DIR}/q_resources.h)
 
-include_directories (${SDL2_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+include_directories (${SDL2_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR} ${OPENGL_INCLUDE_DIR})
 
 set (Q2_SOURCES
   client/cl_cin.c
@@ -84,6 +84,36 @@ add_library (ref-softsdl SHARED
   )
 set_target_properties (ref-softsdl PROPERTIES OUTPUT_NAME ref_softsdl PREFIX "")
 
+if (WITH_QMAX)
+    set (GL_DIR ref_candygl)
+else (WITH_QMAX)
+    set (GL_DIR ref_gl)
+endif (WITH_QMAX)
+
+add_library (ref-sdlgl SHARED
+        ${GL_DIR}/gl_draw.c
+        ${GL_DIR}/gl_image.c
+        ${GL_DIR}/gl_light.c
+        ${GL_DIR}/gl_mesh.c
+        ${GL_DIR}/gl_model.c
+        ${GL_DIR}/gl_rmain.c
+        ${GL_DIR}/gl_rmisc.c
+        ${GL_DIR}/gl_rsurf.c
+        ${GL_DIR}/gl_warp.c
+        linux/qgl_linux.c
+        game/q_shared.c
+        linux/q_shlinux.c
+        linux/glob.c
+        linux/rw_sdl.c
+        linux/rw_linux.c
+        linux/joystick.c
+        )
+if (WITH_QMAX)
+    target_link_libraries (ref-sdlgl ${JPEG_LIBRARY})
+endif (WITH_QMAX)
+target_compile_definitions (ref-sdlgl PRIVATE -DOPENGL)
+set_target_properties (ref-sdlgl PROPERTIES OUTPUT_NAME ref_sdlgl PREFIX "")
+
 add_library (game-base SHARED
   game/g_ai.c
   game/p_client.c
@@ -133,8 +163,8 @@ add_library (game-base SHARED
   game/p_weapon.c
   game/q_shared.c
   game/m_flash.c)
-set_target_properties (game-base PROPERTIES OUTPUT_NAME gamei386 PREFIX "")
+set_target_properties (game-base PROPERTIES OUTPUT_NAME game PREFIX "")
 
 install (TARGETS quake2 RUNTIME DESTINATION bin)
-install (TARGETS ref-softsdl LIBRARY DESTINATION lib/quake2sdl)
+install (TARGETS ref-softsdl ref-sdlgl LIBRARY DESTINATION lib/quake2sdl)
 install (TARGETS game-base LIBRARY DESTINATION lib/quake2sdl/baseq2)

--- a/src/linux/glw_linux.h
+++ b/src/linux/glw_linux.h
@@ -19,7 +19,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 #ifndef __linux__
 #ifndef __FreeBSD__
-#error You shouldnt be including this file on non-unix platforms
+// #error You shouldnt be including this file on non-unix platforms
 #endif
 #endif
 


### PR DESCRIPTION
To test this, also merge: https://github.com/SerenityOS/serenity/pull/12943

This partially reverts commits 470365f7fe and 15795fdcf1 to allow the game to run on x86_64 and to run the OpenGL renderer. Instructions are added to the README.